### PR TITLE
Fix variable name in library

### DIFF
--- a/src/SI4735.cpp
+++ b/src/SI4735.cpp
@@ -418,7 +418,7 @@ void SI4735::radioPowerUp(void)
     // Delay at least 500 ms between powerup command and first tune command to wait for
     // the oscillator to stabilize if XOSCEN is set and crystal is used as the RCLK.
     waitToSend();
-    delay(maxDelayAfterPouwerUp);
+    delay(maxDelayAfterPowerUp);
 
     // Turns the external mute circuit off
     if (audioMuteMcuPin >= 0)
@@ -3149,7 +3149,7 @@ void SI4735::patchPowerUp()
     Wire.write(0b00110001);          // This is a condition for loading the patch: Set to AM, Enable External Crystal Oscillator; Set patch enable; GPO2 output disabled; CTS interrupt disabled. You can change this calling setSSB.
     Wire.write(SI473X_ANALOG_AUDIO); // This is a condition for loading the patch: Set to Analog Output. You can change this calling setSSB.
     Wire.endTransmission();
-    delay(maxDelayAfterPouwerUp);
+    delay(maxDelayAfterPowerUp);
 }
 
 /**
@@ -3594,7 +3594,7 @@ void SI4735::patchPowerUpNBFM()
     Wire.write(0b00110000);          // This is a condition for loading the patch: Set to AM, Enable External Crystal Oscillator; Set patch enable; GPO2 output disabled; CTS interrupt disabled.
     Wire.write(SI473X_ANALOG_AUDIO); // This is a condition for loading the patch: Set to Analog Output. You can change this calling setNBFM.
     Wire.endTransmission();
-    delay(maxDelayAfterPouwerUp);
+    delay(maxDelayAfterPowerUp);
 }
 
 /**

--- a/src/SI4735.h
+++ b/src/SI4735.h
@@ -1081,7 +1081,7 @@ protected:
 
     // Delays
     uint16_t maxDelaySetFrequency = MAX_DELAY_AFTER_SET_FREQUENCY; //!< Stores the maximum delay after set frequency command (in ms).
-    uint16_t maxDelayAfterPouwerUp = MAX_DELAY_AFTER_POWERUP;      //!< Stores the maximum delay you have to setup after a power up command (in ms).
+    uint16_t maxDelayAfterPowerUp = MAX_DELAY_AFTER_POWERUP;      //!< Stores the maximum delay you have to setup after a power up command (in ms).
     unsigned long maxSeekTime = MAX_SEEK_TIME;                     //!< Stores the maximum time (ms) for a seeking process. Defines the maximum seeking time.
 
     uint8_t lastTextFlagAB;
@@ -2696,7 +2696,7 @@ public:
      */
     inline void setMaxDelayPowerUp(uint16_t ms)
     {
-        this->maxDelayAfterPouwerUp = ms;
+        this->maxDelayAfterPowerUp = ms;
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix typo in `maxDelayAfterPowerUp` variable name

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482d0aee64832f8121b8750df76ba2