### PR TITLE
Fix typos and add simple CI compile check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: Arduino CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: arduino/setup-arduino-cli@v1
+        with:
+          version: latest
+      - run: |
+          arduino-cli core update-index
+          arduino-cli core install arduino:avr
+      - run: arduino-cli compile --fqbn arduino:avr:uno examples/SI47XX_01_SERIAL_MONITOR

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,7 +105,7 @@ See the section below for details.
 
 ## Arduino CLI - A faster alternative to the Arduino IDE
 
-Arduino CLI (arduino-cli) is a solution that allows you to compile, build, upload, manage boards and libraries via shell command line. This way, you do not need to use the traditional Arduino IDE. Depending on the development environment you use, arduino-cli may be a good choice given it is conservative on system resources. You will notice that the arduino-cli compiles and uploades code faster. However, it is a command line program, and may present a steeper learning curve over teh Arduio IDE. The links below can help you to learn more about arduino-cli.
+Arduino CLI (arduino-cli) is a solution that allows you to compile, build, upload, manage boards and libraries via shell command line. This way, you do not need to use the traditional Arduino IDE. Depending on the development environment you use, arduino-cli may be a good choice given it is conservative on system resources. You will notice that the arduino-cli compiles and uploads code faster. However, it is a command line program, and may present a steeper learning curve over the Arduino IDE. The links below can help you to learn more about arduino-cli.
 
 * [Click here for more detail about arduino-cli](https://arduino.github.io/arduino-cli/0.21/).
 * [Getting started](https://arduino.github.io/arduino-cli/0.21/getting-started/)

--- a/examples/SI47XX_09_NOKIA_5110/README.md
+++ b/examples/SI47XX_09_NOKIA_5110/README.md
@@ -62,7 +62,7 @@ The schematic below shows the Arduino board based on ATmega 328 and the Nokia 51
 ## User instructions 
 
 
-1. BAND, MODE, AGC/Attenuation, banddwith and STEP
+1. BAND, MODE, AGC/Attenuation, bandwidth and STEP
 
 Press the the correspondent push button and after, rotate the encoder to select the option. For example: 
 To switch the band, press the band button and then rotate the encoder clockwise or counterclockwise. 

--- a/src/SI4735.cpp
+++ b/src/SI4735.cpp
@@ -3618,7 +3618,7 @@ void SI4735::loadPatchNBFM(const uint8_t *patch_content, const uint16_t patch_co
 /**
  * @ingroup group20 Patch and NBFM support
  *
- * @brief Set the radio to FM function.
+ * @brief Set the radio to NBFM function.
  *
  * @todo Adjust the power up parameters
  *

--- a/src/SI4735.h
+++ b/src/SI4735.h
@@ -2826,7 +2826,7 @@ public:
      * @details Some users may be uncomfortable with the loud popping of the speaker during some transitions caused by some SI47XX commands.
      * @details This problem occurs during the transition from the power down to power up.
      * @details For example, when the user changes bands (FM to AM or AM to FM), the Si47XX devices must be powered down and powered up again.
-     * @details If you have a mute circuit attached to a pin on teh MCU, then you can control the mute circuit from the MCU with this function.
+     * @details If you have a mute circuit attached to a pin on the MCU, then you can control the mute circuit from the MCU with this function.
      *
      * @see setHardwareAudioMute
      * @param pin if 0 or greater, sets the MCU digital pin that controls the external circuit.


### PR DESCRIPTION
## Summary
- correct 'teh MCU' typo in audio mute documentation
- fix documentation typos in example READMEs
- clarify `setNBFM` brief comment
- add GitHub Actions workflow using `arduino-cli`

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno examples/SI47XX_01_SERIAL_MONITOR` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482d0b0990832f8f0cb28b56d18c59